### PR TITLE
Add custom types support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module registry.terraform.io/jason-johnson/namep
 go 1.15
 
 require (
+	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1

--- a/internal/provider/datasource_azure_name_test.go
+++ b/internal/provider/datasource_azure_name_test.go
@@ -61,7 +61,7 @@ func TestAccDataSourceAzureName_custom_type_fmt(t *testing.T) {
 				Config: testAccDataSourceAzureName_custom_type_fmt,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.namep_azure_name.rg", "result", "myapp-dev-weu-uxx1-mygroup"),
-					resource.TestCheckResourceAttr("data.namep_azure_name.custom", "result", "app-weu-myapp"),
+					resource.TestCheckResourceAttr("data.namep_azure_name.custom", "result", "thing-dev-weu-uxx1-mycustom"),
 				),
 			},
 		},

--- a/internal/provider/datasource_azure_name_test.go
+++ b/internal/provider/datasource_azure_name_test.go
@@ -52,6 +52,22 @@ func TestAccDataSourceAzureName_custom_rg_fmt(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureName_custom_type_fmt(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureName_custom_type_fmt,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namep_azure_name.rg", "result", "myapp-dev-weu-uxx1-mygroup"),
+					resource.TestCheckResourceAttr("data.namep_azure_name.custom", "result", "app-weu-myapp"),
+				),
+			},
+		},
+	})
+}
+
 // test configurations
 
 const testAccDataSourceAzureName_default_rg = `
@@ -92,5 +108,32 @@ data "namep_azure_name" "wapp" {
   name = "myapp"
 	location = "westeurope"
   type = "azurerm_app_service"
+}
+`
+
+const testAccDataSourceAzureName_custom_type_fmt = `
+provider "namep" {
+  slice_string     = "MYAPP DEV"
+  default_location = "westeurope"
+  extra_tokens = {
+    branch = "uxx1"
+  }
+	default_resource_name_format = "#{TOKEN_1}-#{TOKEN_2}-#{SHORT_LOC}#{-BRANCH}-#{NAME}"
+	default_nodash_name_format = "#{TOKEN_1}#{TOKEN_2}#{SHORT_LOC}#{BRANCH}#{NAME}"
+  resource_formats = {
+    my_type = "thing-#{TOKEN_2}-#{SHORT_LOC}#{-BRANCH}-#{NAME}"
+  }
+}
+
+data "namep_azure_name" "rg" {
+  name = "mygroup"
+	location = "westeurope"
+  type = "azurerm_resource_group"
+}
+
+data "namep_azure_name" "custom" {
+  name = "mycustom"
+	location = "westeurope"
+  type = "my_type"
 }
 `

--- a/internal/provider/validate.go
+++ b/internal/provider/validate.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 
+	"github.com/agext/levenshtein"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -10,20 +11,21 @@ import (
 )
 
 // Annoyingly there is no way in Go to just ignore the map value type even though we don't use it
-func stringInResourceMapKeys(m map[string]ResourceStructure) schema.SchemaValidateDiagFunc {
+func resourceStructureToKeysSlice(m map[string]ResourceStructure) []string {
 	mapKeys := make([]string, 0, len(m))
 	for k := range m {
 		mapKeys = append(mapKeys, k)
 	}
 
-	return stringInSlice(mapKeys)
+	return mapKeys
 }
 
-func stringInSlice(valid []string) schema.SchemaValidateDiagFunc {
-	f := validation.StringInSlice(valid, false)
+func stringIsValidResourceName(m map[string]ResourceStructure) schema.SchemaValidateDiagFunc {
+	valid := resourceStructureToKeysSlice(m)
 
 	return func(v interface{}, path cty.Path) (diags diag.Diagnostics) {
 
+		f := validation.StringInSlice(valid, false)
 		warnings, errors := f(v, fmt.Sprintf("%s", path))
 
 		for _, warn := range warnings {
@@ -35,11 +37,21 @@ func stringInSlice(valid []string) schema.SchemaValidateDiagFunc {
 
 		for _, error := range errors {
 			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
+				Severity: diag.Warning,
 				Summary:  error.Error(),
 			})
 		}
 
 		return diags
 	}
+}
+
+func NameSuggestion(given string, suggestions []string) string {
+	for _, suggestion := range suggestions {
+		dist := levenshtein.Distance(given, suggestion, nil)
+		if dist < 3 { // threshold determined experimentally
+			return suggestion
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Previously if you had some type that was not in the Azure resource list there was no way to make a pattern for it.  It would simply fail when you specified the type.  Now you can make a custom type if you wish and set the format for it.

We cannot validate the type anymore because we would need to read which resource type mappings have been set in the provider but we do not have this information at the time the data_source is validated.